### PR TITLE
chore: bump version to 1.5.0 and unify version management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.18)
+
+if(NOT DEFINED IAXL_PROJECT_VERSION)
+    message(FATAL_ERROR "IAXL_PROJECT_VERSION must be provided by setup.py")
+endif()
+
 project(
     intel-accel-for-llm
-    VERSION 0.10.0
+    VERSION ${IAXL_PROJECT_VERSION}
     LANGUAGES C CXX)
 
 set(DEVICE

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
+VERSION = "1.5.0"
 DEVICE = os.getenv("DEVICE", "cuda")
 PACKAGE_INCLUDES = ["iaxl", "iaxl.*", "kvshrink", "kvshrink.*"]
 
@@ -82,6 +83,8 @@ class CMakeBuild(build_ext):
         else:
             raise RuntimeError("Please ensure either CUDA or XPU is available.")
 
+        cmake_args.append(f"-DIAXL_PROJECT_VERSION={VERSION}")
+
         extra_cmake_args = os.environ.get("IAXL_CMAKE_ARGS", "")
         if extra_cmake_args:
             cmake_args.extend(shlex.split(extra_cmake_args))
@@ -122,7 +125,7 @@ ext_modules.append(CMakeExtension(name="iaxl", sourcedir=ROOT_DIR))
 
 setup(
     name="iaxl",
-    version="0.10.0",
+    version=VERSION,
     description="intel-accel-for-llm",
     author="bin.yang@intel.com",
     packages=find_packages(include=PACKAGE_INCLUDES),

--- a/tools/setup_dsa.sh
+++ b/tools/setup_dsa.sh
@@ -2,46 +2,21 @@
 
 set -euo pipefail
 
-NWQ=${1:-8}
-NUMA=${2:-}
-
-detect_gpu_numa() {
-    local d vendor class node
-    for d in /sys/bus/pci/devices/*; do
-        vendor=$(cat "$d/vendor" 2>/dev/null || echo)
-        [[ "$vendor" == "0x10de" ]] || continue
-        class=$(cat "$d/class" 2>/dev/null || echo)
-        [[ "$class" == 0x03* ]] || continue
-        node=$(cat "$d/numa_node" 2>/dev/null || echo -1)
-        echo "$node"
-        return 0
-    done
-    echo -1
-}
-
-if [[ -z "$NUMA" ]]; then
-    NUMA=$(detect_gpu_numa)
-fi
-if [[ "$NUMA" -lt 0 ]]; then
-    echo "ERROR: could not determine GPU NUMA node; pass it as arg 2" >&2
-    exit 1
-fi
-echo "Target NUMA node (GPU): $NUMA"
+NWQ=${1:-1}
 
 DEVS=()
 for s in /sys/bus/dsa/devices/dsa[0-9]*; do
     [[ -d "$s" ]] || continue
     dev=$(basename "$s")
     [[ "$dev" =~ ^dsa[0-9]+$ ]] || continue
-    node=$(cat "$s/numa_node" 2>/dev/null || echo -1)
-    [[ "$node" == "$NUMA" ]] && DEVS+=("$dev")
+    DEVS+=("$dev")
 done
 
 if [[ ${#DEVS[@]} -eq 0 ]]; then
-    echo "ERROR: no DSA device on NUMA $NUMA" >&2
+    echo "ERROR: no DSA device" >&2
     exit 1
 fi
-echo "DSA devices on NUMA $NUMA: ${DEVS[*]}"
+echo "DSA devices: ${DEVS[*]}"
 
 for DEV in "${DEVS[@]}"; do
     ID=${DEV#dsa}
@@ -95,7 +70,7 @@ for DEV in "${DEVS[@]}"; do
     done
 done
 
-echo "Done. Configured ${#DEVS[@]} device(s) on NUMA $NUMA, $NWQ WQ each:"
+echo "Done. Configured ${#DEVS[@]} device(s), $NWQ WQ each:"
 IDS=()
 WQS=()
 for DEV in "${DEVS[@]}"; do


### PR DESCRIPTION
- Update version from 0.10.0 to 1.5.0 in setup.py
- Centralize version definition in setup.py and pass to CMakeLists.txt via CMake args
- Require IAXL_PROJECT_VERSION to be explicitly provided by setup.py

fix: setup_dsa.sh - simplify DSA device configuration

- Remove NUMA node detection and filtering logic
- Configure all available DSA devices instead of requiring specific NUMA node
- Fixes issue where setup fails when GPU NUMA node cannot be detected